### PR TITLE
ヘッダー追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,8 +19,11 @@
   </head>
 
   <body>
+    <%= render 'shared/header' %>
+
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>
+
   </body>
 </html>

--- a/app/views/memories/top.html.erb
+++ b/app/views/memories/top.html.erb
@@ -5,6 +5,6 @@
   </div>
   <hr class="border-t border-white pb-2 w-full mb-16"><!-- 白線 -->
   <p class="text-white text-xl md:text-2xl mt-4 mb-20 text-center">大切な思い出をオリジナルのアルバムに。</p>
-  <%= link_to "ログイン", "#", class: "bg-white text-black px-6 py-2 rounded-lg text-md md:text-lg font-medium hover:bg-gray-200 mb-8" %>
+  <%= link_to "ログイン", new_user_session_path, class: "bg-white text-black px-6 py-2 rounded-lg text-md md:text-lg font-medium hover:bg-gray-200 mb-8" %>
   <%= link_to "会員登録", "#", class: "text-white underline text-md md:text-lg text-center" %>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,9 @@
   <% if user_signed_in? %>
     <div class="flex flex-wrap items-center ">
       <%= image_tag 'ph_flower-lotus-fill.png', class: "h-10 w-10 md:h-12 md:w-12 mr-4 relative" %>
-      <h1 class="text-white text-3xl md:text-4xl font-extrabold">Memory.</h1>
+      <%= link_to '#', class:"text-white text-3xl md:text-4xl font-extrabold" do %>
+      Memory.</%>
+      <% end %>
     </div>
 
     <div class='flex justify-end py-6 space-x-6 px-12 md:px-24 text-white'>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,9 @@
+  <div class="w-full bg-header py-8">
+    <div class='flex justify-end py-6 space-x-6 px-12 md:px-24 text-white'>
+      <% if user_signed_in? %>
+        <%= link_to 'アルバム作成' %>
+        <%= link_to 'アルバム一覧' %>
+        <%= link_to 'マイページ' %>
+      <% end %>
+    </div>
+  </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,18 @@
-  <div class="w-full bg-header py-8">
+<div class="w-full bg-header py-6">
+  <div class="flex flex-wrap items-center pt-6 pl-4 md:pl-16">
+    <%= image_tag 'ph_flower-lotus-fill.png', class: "h-10 w-10 md:h-12 md:w-12 mr-4 relative" %>
+    <h1 class="text-white text-3xl md:text-4xl font-extrabold">Memory.</h1>
+  </div>
+  <% if user_signed_in? %>
+    <div class="flex flex-wrap items-center ">
+      <%= image_tag 'ph_flower-lotus-fill.png', class: "h-10 w-10 md:h-12 md:w-12 mr-4 relative" %>
+      <h1 class="text-white text-3xl md:text-4xl font-extrabold">Memory.</h1>
+    </div>
+
     <div class='flex justify-end py-6 space-x-6 px-12 md:px-24 text-white'>
-      <% if user_signed_in? %>
         <%= link_to 'アルバム作成' %>
         <%= link_to 'アルバム一覧' %>
         <%= link_to 'マイページ' %>
-      <% end %>
     </div>
-  </div>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,9 @@
 <div class="w-full bg-header py-6">
   <div class="flex flex-wrap items-center pt-6 pl-4 md:pl-16">
     <%= image_tag 'ph_flower-lotus-fill.png', class: "h-10 w-10 md:h-12 md:w-12 mr-4 relative" %>
-    <h1 class="text-white text-3xl md:text-4xl font-extrabold">Memory.</h1>
+    <%= link_to root_path, class:"text-white text-3xl md:text-4xl font-extrabold" do %>
+      Memory.
+    <% end %>
   </div>
   <% if user_signed_in? %>
     <div class="flex flex-wrap items-center ">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -12,7 +12,7 @@
       </div>
 
       <div class="mt-6 flex justify-center">
-        <%= f.submit 'ログイン', class: "w-1/3 bg-blue-400 text-white mt-4 py-2 rounded-md font-semibold hover:bg-blue-500 text-md md:text-lg" %>
+        <%= f.submit 'ログイン', class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-header text-md md:text-lg" %>
       </div>
     <% end %>
   </div>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -12,6 +12,10 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
+      colors: {
+        header: '#1E4874',
+        button: '#86A7DE',
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
## 概要
- ヘッダー追加しました。(ログインしていない場合)
- TOPページのログインボタンからログイン画面へ遷移
- ヘッダーに合わせてボタンの色変更

## 詳細
- ヘッダー( ログインしていない場合 )
  - ロゴのみ表示
  - ロゴクリックしてルートページへ遷移
- TOPページにログイン画面へのパス追加
- ログインページのボタンの色変更

## 動作確認
- TOPページでログインボタンクリックし、ログイン画面に遷移すること確認してください。
- ログイン画面でヘッダーのロゴクリックし、TOP画面に遷移すること確認してください。

## 補足
ログインしている場合の表示や挙動については、別で実装予定です

<img width="1470" alt="スクリーンショット 2025-05-07 10 10 44" src="https://github.com/user-attachments/assets/22d6c681-6f0b-454c-a10e-0389150e8dab" />
