### PR TITLE
会員登録画面追加

### DIFF
--- a/app/views/memories/top.html.erb
+++ b/app/views/memories/top.html.erb
@@ -6,5 +6,5 @@
   <hr class="border-t border-white pb-2 w-full mb-16"><!-- 白線 -->
   <p class="text-white text-xl md:text-2xl mt-4 mb-20 text-center">大切な思い出をオリジナルのアルバムに。</p>
   <%= link_to "ログイン", new_user_session_path, class: "bg-white text-black px-6 py-2 rounded-lg text-md md:text-lg font-medium hover:bg-gray-200 mb-8" %>
-  <%= link_to "会員登録", "#", class: "text-white underline text-md md:text-lg text-center" %>
+  <%= link_to "会員登録",  new_user_registration_path, class: "text-white underline text-md md:text-lg text-center" %>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,27 +4,27 @@
     会員登録
   </div>
 
-  <div class="bg-white rounded-lg w-full max-w-md p-8">
+  <div class="rounded-lg w-full max-w-xl p-8">
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render "users/shared/error_messages", resource: resource %>
 
       <div class="mb-6 flex items-center">
-        <%= f.label :name, "名前：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.label :name, "名前：", class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
         <%= f.text_field :name, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div class="mb-6 flex items-center">
-        <%= f.label :email, "メールアドレス：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.label :email, "メールアドレス：", class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
         <%= f.email_field :email, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div class="mb-6 flex items-center">
-        <%= f.label :password, "パスワード：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.label :password, "パスワード：", class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
         <%= f.password_field :password, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300", placeholder: '6文字以上で設定してください'   %>
       </div>
 
       <div class="mb-6 flex items-center">
-        <%= f.label :password_confirmation, "パスワード(確認)：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.label :password_confirmation, "パスワード(確認)：", class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
         <%= f.password_field :password_confirmation, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,4 +1,3 @@
-
 <div class="w-full flex flex-col items-center">
   <div class="font-semibold text-2xl md:text-3xl mb-6">
     会員登録
@@ -20,18 +19,17 @@
 
       <div class="mb-6 flex items-center">
         <%= f.label :password, "パスワード：", class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
-        <%= f.password_field :password, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300", placeholder: '6文字以上で設定してください'   %>
+        <%= f.password_field :password, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300", placeholder: '6文字以上で設定してください' %>
       </div>
 
       <div class="mb-6 flex items-center">
         <%= f.label :password_confirmation, "パスワード(確認)：", class: "w-full text-gray-700 text-lg md:text-xl pl-8" %>
-        <%= f.password_field :password_confirmation, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+        <%= f.password_field :password_confirmation, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300", placeholder: '6文字以上で設定してください'  %>
       </div>
 
       <div class="mt-6 flex justify-center">
-        <%= f.submit '登録', class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-header text-md md:text-lg" %>
+        <%= f.submit '登録', class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
       </div>
     <% end %>
   </div>
 </div>
-

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,29 +1,37 @@
-<h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="w-full flex flex-col items-center">
+  <div class="font-semibold text-2xl md:text-3xl mb-6">
+    会員登録
   </div>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+  <div class="bg-white rounded-lg w-full max-w-md p-8">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "users/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+      <div class="mb-6 flex items-center">
+        <%= f.label :name, "名前：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.text_field :name, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
+      <div class="mb-6 flex items-center">
+        <%= f.label :email, "メールアドレス：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.email_field :email, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
 
-<%= render "users/shared/links" %>
+      <div class="mb-6 flex items-center">
+        <%= f.label :password, "パスワード：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.password_field :password, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300", placeholder: '6文字以上で設定してください'   %>
+      </div>
+
+      <div class="mb-6 flex items-center">
+        <%= f.label :password_confirmation, "パスワード(確認)：", class: "w-full text-gray-700 text-lg md:text-xl" %>
+        <%= f.password_field :password_confirmation, autofocus: true, class: "w-full border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
+      </div>
+
+      <div class="mt-6 flex justify-center">
+        <%= f.submit '登録', class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-header text-md md:text-lg" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -12,7 +12,7 @@
       </div>
 
       <div class="mt-6 flex justify-center">
-        <%= f.submit 'ログイン', class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-header text-md md:text-lg" %>
+        <%= f.submit 'ログイン', class: "w-1/3 bg-button text-white mt-4 py-2 rounded-md font-semibold hover:bg-change text-md md:text-lg" %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,13 +1,13 @@
 <div class="w-full flex justify-center">
-  <div class="bg-white rounded-lg w-full max-w-md p-8">
+  <div class="rounded-lg w-full max-w-xl p-8">
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="mb-6 flex items-center">
-        <%= f.label :email, "メールアドレス：", class: "w-2/3 text-gray-700 text-lg md:text-xl" %>
+        <%= f.label :email, "メールアドレス：", class: "w-2/3 text-gray-700 text-lg md:text-xl pl-8" %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "w-2/3 border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 
       <div class="mb-6 flex items-center">
-        <%= f.label :password, "パスワード：", class: "w-2/3 text-gray-700 text-lg md:text-xl" %>
+        <%= f.label :password, "パスワード：", class: "w-2/3 text-gray-700 text-lg md:text-xl pl-8" %>
         <%= f.password_field :password, autocomplete: "current-password", class: "w-2/3 border border-gray-300 bg-gray-100 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-300" %>
       </div>
 

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -15,6 +15,7 @@ module.exports = {
       colors: {
         header: '#1E4874',
         button: '#86A7DE',
+        change: '#5E89C5',
       },
     },
   },


### PR DESCRIPTION
## 概要
- 会員登録画面を追加しました
- ログイン画面のログインボタンについて、hover時のカラー変更しました

## 詳細
- 会員登録画面
<img width="1470" alt="スクリーンショット 2025-05-07 15 03 08" src="https://github.com/user-attachments/assets/ea6f70da-2962-4eef-9941-cbb7ff8ddffa" />

- ログイン画面(hover時)
<img width="1470" alt="スクリーンショット 2025-05-07 15 04 31" src="https://github.com/user-attachments/assets/bac84bbf-8755-4e78-98fb-c84f471bd0a6" />

closes #7 
