### PR TITLE
ヘッダーのレイアウト修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,10 @@
   </head>
 
   <body>
-    <%= render 'shared/header' %>
+    <!-- TOP画面のみヘッダー表示しない -->
+    <% unless controller_name == 'memories' && action_name == 'top' %>
+      <%= render 'shared/header' %>
+    <% end %>
 
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,9 +28,9 @@
     </div>
   <% else %>
     <!-- 非ログイン時 -->
-    <div class="flex justify-between items-end px-4 md:px-16 pb-4">
+    <div class="flex justify-between h-40 items-end px-4 md:px-16 pb-4">
       <div class="flex items-end">
-        <%= image_tag 'ph_flower-lotus-fill.png', class: "h-10 w-10 md:h-12 md:w-12 mr-4" %>
+        <%= image_tag 'ph_flower-lotus-fill.png', class: "h-10 w-10 md:h-12 md:w-12 mr-2 md:mr-3 relative top-0.5 md:top-1" %>
         <%= link_to root_path, class:"text-white text-3xl md:text-4xl font-extrabold" do %>
           Memory.
         <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
             マイページ
           </button>
           <div id="js-dropdown" class="absolute right-0 mt-2 w-48 bg-white rounded shadow-lg py-2 z-10 hidden text-gray-800">
-            <div class="block px-4 py-2 text-blue-800 font-bold"><%= current_user.name %> さん</div>
+            <div class="block px-4 py-2 text-blue-900 font-bold underline"><%= current_user.name %> さん</div>
             <%= link_to '会員情報', "#", class: "block px-4 py-2 hover:bg-gray-100" %>
             <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, form: { data: { turbo: false } }, class: "block w-full text-left px-4 py-2 hover:bg-gray-100" %>
           </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,6 +20,7 @@
             マイページ
           </button>
           <div id="js-dropdown" class="absolute right-0 mt-2 w-48 bg-white rounded shadow-lg py-2 z-10 hidden text-gray-800">
+            <div class="block px-4 py-2 text-blue-800 font-bold"><%= current_user.name %> さん</div>
             <%= link_to '会員情報', "#", class: "block px-4 py-2 hover:bg-gray-100" %>
             <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, form: { data: { turbo: false } }, class: "block w-full text-left px-4 py-2 hover:bg-gray-100" %>
           </div>


### PR DESCRIPTION
## 概要
ヘッダーのレイアウト修正しました

## 詳細
- TOPページにてヘッダー非表示にする
- 各画面でのヘッダーのレイアウト統一（幅やアイコン・ロゴの位置など）
- ドロップダウンにログイン者の名前表示欄追加

確認よろしくお願いします

<img width="1470" alt="スクリーンショット 2025-05-08 12 59 28" src="https://github.com/user-attachments/assets/bbce696c-7217-4ee8-8119-471d4f8ba435" />

#70 